### PR TITLE
Fix issue with `quote' function.

### DIFF
--- a/bash/bashlib/bashlib
+++ b/bash/bashlib/bashlib
@@ -1229,7 +1229,7 @@ showHelp() {
 quote() {
 
     # Initialize the defaults.
-    local arg escape=0 quotedArgs=()
+    local arg escape=0 q="'\\''" quotedArgs=()
 
     # Parse the options.
     while [[ $1 = -* ]]; do
@@ -1245,7 +1245,7 @@ quote() {
         if (( escape )); then
             quotedArgs+=("$(printf "%q"     "$arg")")
         else
-            quotedArgs+=("$(printf "'%s'"   "${arg//"'"/"\\'"}")")
+            quotedArgs+=("$(printf "'%s'"   "${arg//"'"/$q}")")
         fi
     done
 


### PR DESCRIPTION
The original function had:

quotedArgs+=("$(printf "'%s'"   "${arg//"'"/"\'"}")")

Which mixes single and double quoting, breaking the escaping. The point is to
use just one type of quotes, but escaping in the RHS of the var/foo/bar
parameter expansion is tricky. So I used a local variable to hold the 4-char
single quote expansion, which should remove the problem.

A simple test:

var="a'b"; . ./bashlib; eval echo "$(quote "$var")";
