### PR TITLE
Change BASH_LINENO test to (return).

### DIFF
--- a/bash/bashlib/bashlib
+++ b/bash/bashlib/bashlib
@@ -1872,7 +1872,7 @@ stackTrace() {
 # |______________________________________________________________________|
 
 # Make sure this file is sourced and not executed.
-(( ! BASH_LINENO )) && {
+(return 2>/dev/null) || {
     emit -R "You should source this file, not execute it."
     exit 1
 }


### PR DESCRIPTION
The (( ! BASH_LINENO )) test fails for this particular case:

  bash -c '. /path/to/bashlib; func'

because BASH_LINENO has a value of zero.

The workaround is to use 'return' in a subshell, which complains when
it is used outside a function or a non-sourced script.

Here are some tests that show that it works for the expected cases:

https://gist.github.com/dualbus/6811562
